### PR TITLE
BPMs: 0 means enabled

### DIFF
--- a/ioc/atip_ioc_entry.py
+++ b/ioc/atip_ioc_entry.py
@@ -12,6 +12,9 @@ require('scipy>=0.16')
 here = os.path.realpath('.')
 sys.path.append(os.path.split(here)[0])
 
+# Nasty monkey-patch to epicsdbbuilder to bypass ValidFieldValue
+from epicsdbbuilder import dbd
+dbd.ValidateDbField.ValidFieldValue = lambda self, name, value: None
 
 from softioc import builder, softioc  # noqa: E402
 from cothread.catools import caget, ca_nothing  # noqa: E402
@@ -49,3 +52,4 @@ builder.LoadDatabase()
 softioc.iocInit()
 
 softioc.interactive_ioc(globals())
+

--- a/ioc/atip_server.py
+++ b/ioc/atip_server.py
@@ -174,7 +174,7 @@ class ATIPServer(object):
         N_BPM = len(self.lattice.get_elements('BPM'))
         builder.SetDeviceName("SR-DI-EBPM-01")
         bpm_enabled_record = builder.Waveform("ENABLED", NELM=N_BPM,
-                                              initial_value=[1]*N_BPM)
+                                              initial_value=[0]*N_BPM)
         self._feedback_records[(0, "bpm_enabled")] = bpm_enabled_record
         print("Finished creating all {0} records.".format(self.total_records))
 


### PR DESCRIPTION
The sense of this value is inverted, 0 means enabled.
With an initial value of 1, CS-DI-IOC-09 sees all BPMs as being disabled and we get some divide-by-zero-type errors.